### PR TITLE
Reorganize function definition location to prevent error on build

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,57 +1,56 @@
-import { Component } from '@angular/core';
+import { Component } from "@angular/core";
 import * as Sentry from "@sentry/browser";
-
-@Component({
-  selector: 'app-root',
-  templateUrl: './app.component.html',
-  styleUrls: ['./app.component.css']
-})
 
 function block(time) {
   const start = performance.now();
   while (performance.now() - start < time) {}
 }
 
+@Component({
+  selector: "app-root",
+  templateUrl: "./app.component.html",
+  styleUrls: ["./app.component.css"],
+})
 export class AppComponent {
-  color = 'black';
-  textValue = '';
-  currentUser = '';
+  color = "black";
+  textValue = "";
+  currentUser = "";
 
   changeColor() {
     var that = this;
-    this.color = 'red';
+    this.color = "red";
     setTimeout(() => {
-      that.color = 'black'
+      that.color = "black";
     }, 1500);
   }
 
   handleSubmit() {
     this.currentUser = this.textValue;
-    Sentry.configureScope(scope => {
-      scope.setUser({email: this.currentUser});
+    Sentry.configureScope((scope) => {
+      scope.setUser({ email: this.currentUser });
     });
   }
 
   malformed() {
-    decodeURIComponent('%');
+    decodeURIComponent("%");
   }
 
   // ERRORS
   notAFunctionError() {
-    var someArray = [{ func: function () {}}];
+    var someArray = [{ func: function () {} }];
     someArray[1].func();
   }
 
   uriError() {
-    decodeURIComponent('%');
+    decodeURIComponent("%");
   }
 
   syntaxError() {
-    eval('foo bar');
+    eval("foo bar");
   }
 
   rangeError() {
-    throw new RangeError('Parameter must be between 1 and 100');
+    throw new RangeError("Parameter must be between 1 and 100");
   }
 
   profilingIssue() {


### PR DESCRIPTION
## Existing Behavior:

- Received error on trying to deploy the app locally:

![Screenshot 2023-10-30 at 10 47 19 AM](https://github.com/sentry-demos/angular/assets/12092849/8661f635-9256-408f-9075-b61961b11f44)

## Fix:

this is due to the location of the block function definition per https://stackoverflow.com/questions/38357384/ts1206-decorators-are-not-valid-here-angular-2:

> The `@Component()` has to be directly before a class, do you have an exported class just below that decorator?

When I swap the location of `block` it gets me past that problem :heavy_check_mark:

![Screenshot 2023-10-30 at 11 06 14 AM](https://github.com/sentry-demos/angular/assets/12092849/a0fd495f-db5b-4a7d-b0aa-9416414c1d3e)

## Result:

I can deploy the app locally.
